### PR TITLE
feat: Add macros from `swift-interception-macros` package

### DIFF
--- a/.github/package.xcworkspace/xcshareddata/xcschemes/InterceptionMacros.xcscheme
+++ b/.github/package.xcworkspace/xcshareddata/xcschemes/InterceptionMacros.xcscheme
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "InterceptionMacros"
+               BuildableName = "InterceptionMacros"
+               BlueprintName = "InterceptionMacros"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "InterceptionMacros"
+            BuildableName = "InterceptionMacros"
+            BlueprintName = "InterceptionMacros"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.github/package.xcworkspace/xcshareddata/xcschemes/InterceptionMacrosPluginTests.xcscheme
+++ b/.github/package.xcworkspace/xcshareddata/xcschemes/InterceptionMacrosPluginTests.xcscheme
@@ -17,9 +17,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "_SwiftInterceptionCustomSelectorsMacrosTests"
-               BuildableName = "_SwiftInterceptionCustomSelectorsMacrosTests"
-               BlueprintName = "_SwiftInterceptionCustomSelectorsMacrosTests"
+               BlueprintIdentifier = "InterceptionMacrosPluginTests"
+               BuildableName = "InterceptionMacrosPluginTests"
+               BlueprintName = "InterceptionMacrosPluginTests"
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>

--- a/.github/package.xcworkspace/xcshareddata/xcschemes/InterceptionMacrosTests.xcscheme
+++ b/.github/package.xcworkspace/xcshareddata/xcschemes/InterceptionMacrosTests.xcscheme
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "InterceptionMacrosTests"
+               BuildableName = "InterceptionMacrosTests"
+               BlueprintName = "InterceptionMacrosTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.github/package.xcworkspace/xcshareddata/xcschemes/_InterceptionCustomSelectors.xcscheme
+++ b/.github/package.xcworkspace/xcshareddata/xcschemes/_InterceptionCustomSelectors.xcscheme
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "_InterceptionCustomSelectors"
+               BuildableName = "_InterceptionCustomSelectors"
+               BlueprintName = "_InterceptionCustomSelectors"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "_InterceptionCustomSelectors"
+            BuildableName = "_InterceptionCustomSelectors"
+            BlueprintName = "_InterceptionCustomSelectors"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.github/package.xcworkspace/xcshareddata/xcschemes/_InterceptionMacros.xcscheme
+++ b/.github/package.xcworkspace/xcshareddata/xcschemes/_InterceptionMacros.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "_SwiftInterceptionUtils"
-               BuildableName = "_SwiftInterceptionUtils"
-               BlueprintName = "_SwiftInterceptionUtils"
+               BlueprintIdentifier = "_InterceptionMacros"
+               BuildableName = "_InterceptionMacros"
+               BlueprintName = "_InterceptionMacros"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
@@ -49,9 +49,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "_SwiftInterceptionUtils"
-            BuildableName = "_SwiftInterceptionUtils"
-            BlueprintName = "_SwiftInterceptionUtils"
+            BlueprintIdentifier = "_InterceptionMacros"
+            BuildableName = "_InterceptionMacros"
+            BlueprintName = "_InterceptionMacros"
             ReferencedContainer = "container:">
          </BuildableReference>
       </MacroExpansion>

--- a/.github/package.xcworkspace/xcshareddata/xcschemes/_InterceptionUtils.xcscheme
+++ b/.github/package.xcworkspace/xcshareddata/xcschemes/_InterceptionUtils.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "_SwiftInterceptionCustomSelectors"
-               BuildableName = "_SwiftInterceptionCustomSelectors"
-               BlueprintName = "_SwiftInterceptionCustomSelectors"
+               BlueprintIdentifier = "_InterceptionUtils"
+               BuildableName = "_InterceptionUtils"
+               BlueprintName = "_InterceptionUtils"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
@@ -49,9 +49,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "_SwiftInterceptionCustomSelectors"
-            BuildableName = "_SwiftInterceptionCustomSelectors"
-            BlueprintName = "_SwiftInterceptionCustomSelectors"
+            BlueprintIdentifier = "_InterceptionUtils"
+            BuildableName = "_InterceptionUtils"
+            BlueprintName = "_InterceptionUtils"
             ReferencedContainer = "container:">
          </BuildableReference>
       </MacroExpansion>

--- a/.github/package.xcworkspace/xcshareddata/xcschemes/swift-interception-Package.xcscheme
+++ b/.github/package.xcworkspace/xcshareddata/xcschemes/swift-interception-Package.xcscheme
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Interception"
+               BuildableName = "Interception"
+               BlueprintName = "Interception"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "InterceptionMacros"
+               BuildableName = "InterceptionMacros"
+               BlueprintName = "InterceptionMacros"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "_InterceptionCustomSelectors"
+               BuildableName = "_InterceptionCustomSelectors"
+               BlueprintName = "_InterceptionCustomSelectors"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "_InterceptionMacros"
+               BuildableName = "_InterceptionMacros"
+               BlueprintName = "_InterceptionMacros"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "_InterceptionUtils"
+               BuildableName = "_InterceptionUtils"
+               BlueprintName = "_InterceptionUtils"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "InterceptionMacrosPluginTests"
+               BuildableName = "InterceptionMacrosPluginTests"
+               BlueprintName = "InterceptionMacrosPluginTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "InterceptionMacrosTests"
+               BuildableName = "InterceptionMacrosTests"
+               BlueprintName = "InterceptionMacrosTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "InterceptionTests"
+               BuildableName = "InterceptionTests"
+               BlueprintName = "InterceptionTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "InterceptionMacrosPluginTests"
+               BuildableName = "InterceptionMacrosPluginTests"
+               BlueprintName = "InterceptionMacrosPluginTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "InterceptionMacrosTests"
+               BuildableName = "InterceptionMacrosTests"
+               BlueprintName = "InterceptionMacrosTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "InterceptionTests"
+               BuildableName = "InterceptionTests"
+               BlueprintName = "InterceptionTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "Interception"
+            BuildableName = "Interception"
+            BlueprintName = "Interception"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           - release
     steps:
     - uses: actions/checkout@v4
-    - name: Select Xcode 15.1
-      run: sudo xcode-select -s /Applications/Xcode_15.1.app
-    - name: Run tests
-      run: make CONFIG=debug test-library
+    - name: Select Xcode 15.2
+      run: sudo xcode-select -s /Applications/Xcode_15.2.app
+    - name: Run test
+      run: make test

--- a/.swiftpm/xcode/xcshareddata/xcschemes/InterceptionMacros.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/InterceptionMacros.xcscheme
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "InterceptionMacros"
+               BuildableName = "InterceptionMacros"
+               BlueprintName = "InterceptionMacros"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "InterceptionMacros"
+            BuildableName = "InterceptionMacros"
+            BlueprintName = "InterceptionMacros"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/InterceptionMacrosPluginTests.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/InterceptionMacrosPluginTests.xcscheme
@@ -17,9 +17,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "_SwiftInterceptionCustomSelectorsMacrosTests"
-               BuildableName = "_SwiftInterceptionCustomSelectorsMacrosTests"
-               BlueprintName = "_SwiftInterceptionCustomSelectorsMacrosTests"
+               BlueprintIdentifier = "InterceptionMacrosPluginTests"
+               BuildableName = "InterceptionMacrosPluginTests"
+               BlueprintName = "InterceptionMacrosPluginTests"
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/InterceptionMacrosTests.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/InterceptionMacrosTests.xcscheme
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "InterceptionMacrosTests"
+               BuildableName = "InterceptionMacrosTests"
+               BlueprintName = "InterceptionMacrosTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/_InterceptionCustomSelectors.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/_InterceptionCustomSelectors.xcscheme
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "_InterceptionCustomSelectors"
+               BuildableName = "_InterceptionCustomSelectors"
+               BlueprintName = "_InterceptionCustomSelectors"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "_InterceptionCustomSelectors"
+            BuildableName = "_InterceptionCustomSelectors"
+            BlueprintName = "_InterceptionCustomSelectors"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/_InterceptionMacros.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/_InterceptionMacros.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "_SwiftInterceptionUtils"
-               BuildableName = "_SwiftInterceptionUtils"
-               BlueprintName = "_SwiftInterceptionUtils"
+               BlueprintIdentifier = "_InterceptionMacros"
+               BuildableName = "_InterceptionMacros"
+               BlueprintName = "_InterceptionMacros"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
@@ -49,9 +49,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "_SwiftInterceptionUtils"
-            BuildableName = "_SwiftInterceptionUtils"
-            BlueprintName = "_SwiftInterceptionUtils"
+            BlueprintIdentifier = "_InterceptionMacros"
+            BuildableName = "_InterceptionMacros"
+            BlueprintName = "_InterceptionMacros"
             ReferencedContainer = "container:">
          </BuildableReference>
       </MacroExpansion>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/_InterceptionUtils.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/_InterceptionUtils.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "_SwiftInterceptionCustomSelectors"
-               BuildableName = "_SwiftInterceptionCustomSelectors"
-               BlueprintName = "_SwiftInterceptionCustomSelectors"
+               BlueprintIdentifier = "_InterceptionUtils"
+               BuildableName = "_InterceptionUtils"
+               BlueprintName = "_InterceptionUtils"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
@@ -49,9 +49,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "_SwiftInterceptionCustomSelectors"
-            BuildableName = "_SwiftInterceptionCustomSelectors"
-            BlueprintName = "_SwiftInterceptionCustomSelectors"
+            BlueprintIdentifier = "_InterceptionUtils"
+            BuildableName = "_InterceptionUtils"
+            BlueprintName = "_InterceptionUtils"
             ReferencedContainer = "container:">
          </BuildableReference>
       </MacroExpansion>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/swift-interception-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/swift-interception-Package.xcscheme
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Interception"
+               BuildableName = "Interception"
+               BlueprintName = "Interception"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "InterceptionMacros"
+               BuildableName = "InterceptionMacros"
+               BlueprintName = "InterceptionMacros"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "_InterceptionCustomSelectors"
+               BuildableName = "_InterceptionCustomSelectors"
+               BlueprintName = "_InterceptionCustomSelectors"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "_InterceptionMacros"
+               BuildableName = "_InterceptionMacros"
+               BlueprintName = "_InterceptionMacros"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "_InterceptionUtils"
+               BuildableName = "_InterceptionUtils"
+               BlueprintName = "_InterceptionUtils"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "InterceptionMacrosPluginTests"
+               BuildableName = "InterceptionMacrosPluginTests"
+               BlueprintName = "InterceptionMacrosPluginTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "InterceptionMacrosTests"
+               BuildableName = "InterceptionMacrosTests"
+               BlueprintName = "InterceptionMacrosTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "InterceptionTests"
+               BuildableName = "InterceptionTests"
+               BlueprintName = "InterceptionTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "InterceptionMacrosPluginTests"
+               BuildableName = "InterceptionMacrosPluginTests"
+               BlueprintName = "InterceptionMacrosPluginTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "InterceptionMacrosTests"
+               BuildableName = "InterceptionMacrosTests"
+               BlueprintName = "InterceptionMacrosTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "InterceptionTests"
+               BuildableName = "InterceptionTests"
+               BlueprintName = "InterceptionTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "Interception"
+            BuildableName = "Interception"
+            BlueprintName = "Interception"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,41 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-macro-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-macro-testing.git",
+      "state" : {
+        "revision" : "10dcef36314ddfea6f60442169b0b320204cbd35",
+        "version" : "0.2.2"
+      }
+    },
+    {
+      "identity" : "swift-macro-toolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stackotter/swift-macro-toolkit.git",
+      "state" : {
+        "revision" : "106daeb38eb3f52b1540aed981fc63fa22274576",
+        "version" : "0.3.1"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "state" : {
+        "revision" : "8e68404f641300bfd0e37d478683bb275926760c",
+        "version" : "1.15.2"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "74203046135342e4a4a627476dd6caf8b28fe11b",
+        "version" : "509.0.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,13 +1,27 @@
 // swift-tools-version: 5.9
+
 import PackageDescription
+import CompilerPluginSupport
 
 let package = Package(
 	name: "swift-interception",
+	platforms: [
+		.iOS(.v13),
+		.macOS(.v10_15),
+		.tvOS(.v13),
+		.macCatalyst(.v13),
+		.watchOS(.v6)
+	],
 	products: [
 		.library(
 			name: "_InterceptionCustomSelectors",
 			type: .static,
 			targets: ["_InterceptionCustomSelectors"]
+		),
+		.library(
+			name: "_InterceptionMacros",
+			type: .static,
+			targets: ["_InterceptionMacros"]
 		),
 		.library(
 			name: "_InterceptionUtils",
@@ -18,9 +32,31 @@ let package = Package(
 			name: "Interception",
 			type: .static,
 			targets: ["Interception"]
+		),
+		.library(
+			name: "InterceptionMacros",
+			type: .static,
+			targets: ["InterceptionMacros"]
+		),
+	],
+	dependencies: [
+		.package(
+			url: "https://github.com/stackotter/swift-macro-toolkit.git",
+			.upToNextMinor(from: "0.3.0")
+		),
+		.package(
+			url: "https://github.com/pointfreeco/swift-macro-testing.git",
+			.upToNextMinor(from: "0.2.2")
 		)
 	],
 	targets: [
+		.target(
+			name: "_InterceptionMacros",
+			dependencies: [
+				.target(name: "InterceptionMacrosPlugin"),
+				.target(name: "_InterceptionCustomSelectors")
+			]
+		),
 		.target(name: "_InterceptionCustomSelectors"),
 		.target(name: "_InterceptionUtilsObjc"),
 		.target(
@@ -36,10 +72,39 @@ let package = Package(
 				.target(name: "_InterceptionUtils"),
 			]
 		),
+		.target(
+			name: "InterceptionMacros",
+			dependencies: [
+				.target(name: "_InterceptionMacros"),
+				.target(name: "Interception")
+			]
+		),
+		.macro(
+			name: "InterceptionMacrosPlugin",
+			dependencies: [
+				.product(
+					name: "MacroToolkit",
+					package: "swift-macro-toolkit"
+				)
+			]
+		),
+		.testTarget(
+			name: "InterceptionMacrosPluginTests",
+			dependencies: [
+				.target(name: "InterceptionMacrosPlugin"),
+				.product(name: "MacroTesting", package: "swift-macro-testing"),
+			]
+		),
 		.testTarget(
 			name: "InterceptionTests",
 			dependencies: [
 				.target(name: "Interception"),
+			]
+		),
+		.testTarget(
+			name: "InterceptionMacrosTests",
+			dependencies: [
+				.target(name: "InterceptionMacros"),
 			]
 		),
 	]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # swift-interception
 
-[![SwiftPM 5.9](https://img.shields.io/badge/swiftpm-5.9-ED523F.svg?style=flat)](https://swift.org/download/) ![Platforms](https://img.shields.io/badge/Platforms-iOS_|_macOS_|_Catalyst_|_tvOS_|_watchOS-ED523F.svg?style=flat) [![@capturecontext](https://img.shields.io/badge/contact-@capturecontext-1DA1F2.svg?style=flat&logo=twitter)](https://twitter.com/capture_context) 
+[![SwiftPM 5.9](https://img.shields.io/badge/swiftpm-5.9-ED523F.svg?style=flat)](https://swift.org/download/) ![Platforms](https://img.shields.io/badge/Platforms-iOS_13_|_macOS_10.15_|_Catalyst_13_|_tvOS_13_|_watchOS_7-ED523F.svg?style=flat) [![@capturecontext](https://img.shields.io/badge/contact-@capturecontext-1DA1F2.svg?style=flat&logo=twitter)](https://twitter.com/capture_context) 
 
 Package for interception of objc selectors in Swift.
-
-Macros: [`swift-interception-macros`](https://github.com/capturecontext/swift-interception-macros)
 
 ## Usage
 
@@ -18,13 +16,28 @@ import Interception
 navigationController.setInterceptionHandler(
   for: _makeMethodSelector(
     selector: UINavigationController.popViewController,
-    signature: UINavigationController.popViewController
+    signature: navigationController.popViewController
   )
 ) { result in 
   print(result.args) // `animated` flag
   print(result.output) // popped `UIViewController?`
 }
 ```
+
+You can also simplify creating method selector with `InterceptionMacros` if you are open for macros
+
+```swift
+import InterceptionMacros
+
+navigationController.setInterceptionHandler(
+  for: #methodSelector(UINavigationController.popViewController)
+) { result in 
+  print(result.args) // `animated` flag
+  print(result.output) // popped `UIViewController?`
+}
+```
+
+> Macros require `swift-syntax` compilation, so it will affect cold compilation time
 
 You can set up multiple interception handlers as well, just make sure that you use different keys for each handler
 
@@ -36,6 +49,20 @@ object.setInterceptionHandler(
     selector: #selector(MyObject.someMethod(arg1:arg2)),
     signature: MyObject.someMethod(arg1:arg2)
   ),
+  key: "argumentsPrinter"
+) { result in 
+  // In case of multiple arguments
+  // you can access them as a tuple
+  print(result.args.0)
+  print(result.args.1)
+}
+```
+
+```swift
+import InterceptionMacros
+
+object.setInterceptionHandler(
+  for: #methodSelector(MyObject.someMethod(arg1:arg2)),
   key: "argumentsPrinter"
 ) { result in 
   // In case of multiple arguments
@@ -61,13 +88,13 @@ Also you may find some `@_spi` methods and Utils helpful
 import _InterceptionUtils // Is not shown in the autocomplete
 ```
 
-<!--- See [`combine-interception`](https://github.com/capturecontext/combine-interception) for usage example. --->
+See [`combine-interception`](https://github.com/capturecontext/combine-interception) for usage example.
 
 ## Installation
 
 ### Basic
 
-You can add CombineInterception to an Xcode project by adding it as a package dependency.
+You can add Interception to an Xcode project by adding it as a package dependency.
 
 1. From the **File** menu, select **Swift Packages › Add Package Dependency…**
 2. Enter [`"https://github.com/capturecontext/swift-interception.git"`](https://github.com/capturecontext/swift-interception.git) into the package repository URL text field
@@ -92,6 +119,15 @@ Do not forget about target dependencies:
   package: "swift-interception"
 )
 ```
+
+```swift
+.product(
+  name: "InterceptionMacros",
+  package: "swift-interception"
+)
+```
+
+
 
 ## License
 

--- a/Sources/InterceptionMacros/Exports.swift
+++ b/Sources/InterceptionMacros/Exports.swift
@@ -1,0 +1,2 @@
+@_exported import Interception
+@_exported import _InterceptionMacros

--- a/Sources/InterceptionMacrosPlugin/Macros/MethodSelectorMacro.swift
+++ b/Sources/InterceptionMacrosPlugin/Macros/MethodSelectorMacro.swift
@@ -1,0 +1,24 @@
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+import Foundation
+
+public struct MethodSelectorMacro: ExpressionMacro {
+	public static func expansion<
+		Node: FreestandingMacroExpansionSyntax,
+		Context: MacroExpansionContext
+	>(
+		of node: Node,
+		in context: Context
+	) -> ExprSyntax {
+		guard let arg = node.argumentList.first.map(\.expression)
+		else { fatalError("compiler bug: the macro does not have any arguments") }
+
+		return """
+		_makeMethodSelector(
+			selector: #selector(\(arg)),
+			signature: \(arg)
+		)
+		"""
+	}
+}

--- a/Sources/InterceptionMacrosPlugin/Macros/PropertySelectorMacro.swift
+++ b/Sources/InterceptionMacrosPlugin/Macros/PropertySelectorMacro.swift
@@ -1,0 +1,20 @@
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public struct PropertySelectorMacro: ExpressionMacro {
+	public static func expansion<
+		Node: FreestandingMacroExpansionSyntax,
+		Context: MacroExpansionContext
+	>(
+		of node: Node,
+		in context: Context
+	) -> ExprSyntax {
+		guard let arg = node.argumentList.first.map(\.expression)
+		else { fatalError("compiler bug: the macro does not have any arguments") }
+
+		return """
+		_unsafeMakePropertySelector(\(arg))
+		"""
+	}
+}

--- a/Sources/InterceptionMacrosPlugin/Plugin.swift
+++ b/Sources/InterceptionMacrosPlugin/Plugin.swift
@@ -1,0 +1,11 @@
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+
+@main
+struct Plugin: CompilerPlugin {
+	let providingMacros: [Macro.Type] = [
+		MethodSelectorMacro.self,
+		PropertySelectorMacro.self
+	]
+}
+

--- a/Sources/_InterceptionMacros/Macros.swift
+++ b/Sources/_InterceptionMacros/Macros.swift
@@ -1,0 +1,72 @@
+import Foundation
+import _InterceptionCustomSelectors
+
+// MARK: - PropertySelectors
+
+@freestanding(expression)
+public macro propertySelector<Object: NSObject, Value>(
+	_: KeyPath<Object, Value>
+) -> _ReadonlyPropertySelector<Value> =
+#externalMacro(module: "InterceptionMacrosPlugin", type: "PropertySelectorMacro")
+
+@freestanding(expression)
+public macro propertySelector<Object: NSObject, Value>(
+	_: WritableKeyPath<Object, Value>
+) -> _MutablePropertySelector<Value> =
+#externalMacro(module: "InterceptionMacrosPlugin", type: "PropertySelectorMacro")
+
+// MARK: - MethodSelectors
+
+@freestanding(expression)
+public macro methodSelector<Output>(
+	_: (() -> Output)?
+) -> _MethodSelector<Void, Output> =
+#externalMacro(module: "InterceptionMacrosPlugin", type: "MethodSelectorMacro")
+
+@freestanding(expression)
+public macro methodSelector<Arg, Output>(
+	_: ((Arg) -> Output)?
+) -> _MethodSelector<Arg, Output> =
+#externalMacro(module: "InterceptionMacrosPlugin", type: "MethodSelectorMacro")
+
+@freestanding(expression)
+public macro methodSelector<each Arg, Output>(
+	_: ((repeat each Arg) -> Output)?
+) -> _MethodSelector<(repeat each Arg), Output> =
+#externalMacro(module: "InterceptionMacrosPlugin", type: "MethodSelectorMacro")
+
+@freestanding(expression)
+public macro methodSelector<Object, Output>(
+	_: (Object) -> (() -> Output)?
+) -> _MethodSelector<Void, Output> =
+#externalMacro(module: "InterceptionMacrosPlugin", type: "MethodSelectorMacro")
+
+@freestanding(expression)
+public macro methodSelector<Object, Arg, Output>(
+	_: (Object) -> ((Arg) -> Output)?
+) -> _MethodSelector<Arg, Output> =
+#externalMacro(module: "InterceptionMacrosPlugin", type: "MethodSelectorMacro")
+
+@freestanding(expression)
+public macro methodSelector<Object, each Arg, Output>(
+	_: (Object) -> ((repeat each Arg) -> Output)?
+) -> _MethodSelector<(repeat each Arg), Output> =
+#externalMacro(module: "InterceptionMacrosPlugin", type: "MethodSelectorMacro")
+
+@freestanding(expression)
+public macro methodSelector<Object, Output>(
+	_: (Object) -> () -> Output
+) -> _MethodSelector<Void, Output> =
+#externalMacro(module: "InterceptionMacrosPlugin", type: "MethodSelectorMacro")
+
+@freestanding(expression)
+public macro methodSelector<Object, Arg, Output>(
+	_: (Object) -> (Arg) -> Output
+) -> _MethodSelector<Arg, Output> =
+#externalMacro(module: "InterceptionMacrosPlugin", type: "MethodSelectorMacro")
+
+@freestanding(expression)
+public macro methodSelector<Object, each Arg, Output>(
+	_: (Object) -> (repeat each Arg) -> Output
+) -> _MethodSelector<(repeat each Arg), Output> =
+#externalMacro(module: "InterceptionMacrosPlugin", type: "MethodSelectorMacro")

--- a/Tests/InterceptionMacrosPluginTests/MethodSelectorTests.swift
+++ b/Tests/InterceptionMacrosPluginTests/MethodSelectorTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+import MacroTesting
+import InterceptionMacrosPlugin
+
+final class MethodSelectorTests: XCTestCase {
+	override func invokeTest() {
+		withMacroTesting(
+			isRecording: false,
+			macros: [
+				"methodSelector": MethodSelectorMacro.self
+			]
+		) {
+			super.invokeTest()
+		}
+	}
+
+	func testApplication() {
+		assertMacro {
+			"""
+			#methodSelector(Object.someFunc)
+			"""
+		} expansion: {
+			"""
+			_makeMethodSelector(
+				selector: #selector(Object.someFunc),
+				signature: Object.someFunc
+			)
+			"""
+		}
+	}
+}

--- a/Tests/InterceptionMacrosPluginTests/PropertySelectorTests.swift
+++ b/Tests/InterceptionMacrosPluginTests/PropertySelectorTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+import MacroTesting
+import InterceptionMacrosPlugin
+
+final class PropertySelectorTests: XCTestCase {
+	override func invokeTest() {
+		withMacroTesting(
+			isRecording: false,
+			macros: [
+				"propertySelector": PropertySelectorMacro.self
+			]
+		) {
+			super.invokeTest()
+		}
+	}
+
+	func testApplication() {
+		assertMacro {
+			#"""
+			#propertySelector(\Object.someProperty)
+			"""#
+		} expansion: {
+			#"""
+			_unsafeMakePropertySelector(\Object.someProperty)
+			"""#
+		}
+	}
+}

--- a/Tests/InterceptionMacrosTests/InterceptionMacrosTests.swift
+++ b/Tests/InterceptionMacrosTests/InterceptionMacrosTests.swift
@@ -1,0 +1,163 @@
+import XCTest
+@testable import InterceptionMacros
+
+final class InterceptionMacrosTests: XCTestCase {
+	func testNoInputWithOutput() {
+		let object = Object()
+		var _args: [Void] = []
+		var _outputs: [Int] = []
+		var _expectedOutputs: [Int] = []
+		var _count = 0
+
+		object.setInterceptionHandler(for: #methodSelector(Object.zero)) { result in
+			_args.append(result.args)
+			_outputs.append(result.output)
+			_count += 1
+		}
+
+		let runs = 3
+		for _ in 0..<runs {
+			_expectedOutputs.append(object.zero())
+		}
+
+		XCTAssertEqual(_count, runs)
+		XCTAssertEqual(_args.count, runs)
+		XCTAssertEqual(_outputs, _expectedOutputs)
+	}
+
+	func testInputWithNoOutput() {
+		let object = Object()
+		var _args: [Int] = []
+		var _outputs: [Void] = []
+		var _count = 0
+
+		object.setInterceptionHandler(for: #methodSelector(Object.discard)) { result in
+			_args.append(result.args)
+			_outputs.append(result.output)
+			_count += 1
+		}
+
+		let runs = 3
+		for i in 0..<runs { object.discard(i) }
+
+		XCTAssertEqual(_count, runs)
+		XCTAssertEqual(_args, .init(0..<runs))
+		XCTAssertEqual(_outputs.count, runs)
+	}
+
+	func testInputWithOutput() {
+		let object = Object()
+		var _args: [Int] = []
+		var _outputs: [Bool] = []
+		var _expectedOutputs: [Bool] = []
+		var _count = 0
+
+		object.setInterceptionHandler(for: #methodSelector(Object.booleanForInteger)) { result in
+			_args.append(result.args)
+			_outputs.append(result.output)
+			_count += 1
+		}
+
+		let runs = 3
+		for i in 0..<runs {
+			_expectedOutputs.append(object.booleanForInteger(i))
+		}
+
+		XCTAssertEqual(_count, runs)
+		XCTAssertEqual(_args, .init(0..<runs))
+		XCTAssertEqual(_outputs, _expectedOutputs)
+	}
+
+	func testSimpleMultipleInputsWithOutput() {
+		let object = Object()
+		var _args: [(Int, Int)] = []
+		var _outputs: [Bool] = []
+		var _expectedArgs: [(Int, Int)] = []
+		var _expectedOutputs: [Bool] = []
+		var _count = 0
+
+		object.setInterceptionHandler(for: #methodSelector(Object.booleanAndForTwoIntegers)) { result in
+			_args.append(result.args)
+			_outputs.append(result.output)
+			_count += 1
+		}
+
+		let outerRuns = 3
+		let innerRuns = 3
+		let runs = outerRuns * innerRuns
+		for i in 0..<outerRuns {
+			for j in 0..<innerRuns {
+				_expectedArgs.append((i, j))
+				_expectedOutputs.append(object.booleanAndForTwoIntegers(i, j))
+			}
+		}
+
+		XCTAssertEqual(_count, runs)
+		XCTAssertEqual(_args.map(Pair.init), _expectedArgs.map(Pair.init))
+		XCTAssertEqual(_outputs, _expectedOutputs)
+	}
+
+	func testMultipleInputsWithOutput() {
+		let object = Object()
+		var _args: [(Int, Bool)] = []
+		var _outputs: [String] = []
+		var _expectedArgs: [(Int, Bool)] = []
+		var _expectedOutputs: [String] = []
+		var _count = 0
+
+		object.setInterceptionHandler(for: #methodSelector(Object.toString)) { result in
+			_args.append(result.args)
+			_outputs.append(result.output)
+			_count += 1
+		}
+
+		let outerRuns = 3
+		let innerRuns = 3
+		let runs = outerRuns * innerRuns
+		for i in 0..<outerRuns {
+			for j in 0..<innerRuns {
+				_expectedArgs.append((i, j.isMultiple(of: 2)))
+				_expectedOutputs.append(object.toString(i, j.isMultiple(of: 2)))
+			}
+		}
+
+		XCTAssertEqual(_count, runs)
+		XCTAssertEqual(_args.map(Pair.init), _expectedArgs.map(Pair.init))
+		XCTAssertEqual(_outputs, _expectedOutputs)
+	}
+}
+
+fileprivate class Object: NSObject {
+	@discardableResult
+	@objc dynamic
+	func zero() -> Int { 0 }
+
+	@objc dynamic
+	func discard(_ value: Int) {}
+
+	@discardableResult
+	@objc dynamic
+	func booleanForInteger(_ value: Int) -> Bool {
+		value != 0
+	}
+
+	@objc dynamic
+	func booleanAndForTwoIntegers(_ first: Int, _ second: Int) -> Bool {
+		booleanForInteger(first) && booleanForInteger(second)
+	}
+
+	@objc dynamic
+	func toString(_ first: Int, _ second: Bool) -> String {
+		String(describing: (first, second))
+	}
+}
+
+fileprivate struct Pair<Left: Equatable, Right: Equatable>: Equatable {
+	var left: Left
+	var right: Right
+
+	init(_ pair: (Left, Right)) {
+		self.left = pair.0
+		self.right = pair.1
+	}
+}


### PR DESCRIPTION
Macros approach is aligned with https://github.com/pointfreeco/swift-dependencies
Now they are a part of this package, but have a separate target

Pros vs shared target:
- Optional use of macros, core features are available without use of macros (macros increase cold compilation time, so not everyone is down to depend on them)

Pros vs separate macros package:
- Much easier to maintain
- Easier to import

Cons vs separate macros package:
- swift-syntax has to be resolved even if client doesn't use macros (however compilation time is not affected if client opts-out macros)

Notes:
- `_InterceptionMacros` target declares macros without exporting `Interception` target, this might be helpful for higher-order libraries development for example `combine-interception` may hide `Interception` APIs to constrain interception to Combine APIs, on the other hand `InterceptionMacros` target exports `Interception` for convenience.